### PR TITLE
#10; Simple table creation for tables that doesn't exist

### DIFF
--- a/dal/datastore.go
+++ b/dal/datastore.go
@@ -5,7 +5,7 @@ import "github.com/ishehata/gofixtures/entity"
 // Datastore interface defines the methods needed to be implemented
 // by different database drivers
 type Datastore interface {
-	Connect(config entity.DBConfig) error
-	Insert(entity.Fixture) error
+	Connect() error
+	Insert(fixture entity.Fixture) error
 	Close()
 }

--- a/dal/postgres/postgres.go
+++ b/dal/postgres/postgres.go
@@ -38,7 +38,7 @@ func (datastore *postgresDatastore) Connect() error {
 func (datastore *postgresDatastore) createTable(tableName string, columns []string) error {
 	columnsDef := strings.Join(columns, " VARCHAR, ")
 	columnsDef += " VARCHAR"
-	q := fmt.Sprintf("CREATE TABLE TABLE IF NOT EXISTS public.%s (%s)", tableName, columnsDef)
+	q := fmt.Sprintf("CREATE TABLE IF NOT EXISTS public.%s (%s)", tableName, columnsDef)
 	_, err := datastore.db.Exec(q)
 	return err
 }
@@ -58,7 +58,6 @@ func (datastore *postgresDatastore) Insert(fixture entity.Fixture) error {
 	if err != nil {
 		return err
 	}
-	log.Println("datastore.config.AutoCreateTables", datastore.config.AutoCreateTables)
 	if datastore.config.AutoCreateTables {
 		columnsList := keys(fixture.Records[0])
 		if err := datastore.createTable(fixture.Table, columnsList); err != nil {

--- a/dal/postgres/postgres.go
+++ b/dal/postgres/postgres.go
@@ -2,6 +2,8 @@ package postgres
 
 import (
 	"fmt"
+	"log"
+	"strings"
 
 	"github.com/ishehata/gofixtures/dal"
 	"github.com/ishehata/gofixtures/entity"
@@ -10,17 +12,20 @@ import (
 )
 
 // New Creates
-func New() dal.Datastore {
-	return &postgresDatastore{}
+func New(config entity.DBConfig) dal.Datastore {
+	return &postgresDatastore{
+		config: config,
+	}
 }
 
 type postgresDatastore struct {
-	db *sqlx.DB
+	db     *sqlx.DB
+	config entity.DBConfig
 }
 
 // Connect connects to postgresql db based on parameters of DBConfig object
-func (datastore *postgresDatastore) Connect(conf entity.DBConfig) error {
-	connString := buildConnectionString(conf)
+func (datastore *postgresDatastore) Connect() error {
+	connString := buildConnectionString(datastore.config)
 	// open connection and ping
 	db, err := sqlx.Connect("postgres", connString)
 	if err != nil {
@@ -30,10 +35,35 @@ func (datastore *postgresDatastore) Connect(conf entity.DBConfig) error {
 	return nil
 }
 
+func (datastore *postgresDatastore) createTable(tableName string, columns []string) error {
+	columnsDef := strings.Join(columns, " VARCHAR, ")
+	columnsDef += " VARCHAR"
+	q := fmt.Sprintf("CREATE TABLE TABLE IF NOT EXISTS public.%s (%s)", tableName, columnsDef)
+	_, err := datastore.db.Exec(q)
+	return err
+}
+
+func keys(m map[string]interface{}) []string {
+	keys := make([]string, len(m))
+	i := 0
+	for k := range m {
+		keys[i] = k
+		i++
+	}
+	return keys
+}
+
 func (datastore *postgresDatastore) Insert(fixture entity.Fixture) error {
 	tx, err := datastore.db.Begin()
 	if err != nil {
 		return err
+	}
+	log.Println("datastore.config.AutoCreateTables", datastore.config.AutoCreateTables)
+	if datastore.config.AutoCreateTables {
+		columnsList := keys(fixture.Records[0])
+		if err := datastore.createTable(fixture.Table, columnsList); err != nil {
+			log.Fatal(err)
+		}
 	}
 	for _, record := range fixture.Records {
 		query := buildNamedQuery(fixture.Table, record)

--- a/dal/postgres/postgres_test.go
+++ b/dal/postgres/postgres_test.go
@@ -24,33 +24,23 @@ func prepareTestData(numberOfRecords int) entity.Fixture {
 	return fixture
 }
 
-func prepareDatastoreTables(datastore *postgresDatastore) {
-	datastore.db.MustExec(`
-		CREATE TABLE IF NOT EXISTS products (
-			name varchar(255),
-			slug varchar(255)
-		);
-	`)
-}
-
 func TestInsertion(t *testing.T) {
 	fixture := prepareTestData(100)
 
 	dbConfig := entity.DBConfig{
-		Driver:   "postgres",
-		Database: os.Getenv("GOFIXTURES_TEST_DB_NAME"),
-		User:     os.Getenv("GOFIXTURES_TEST_DB_USER"),
-		Password: os.Getenv("GOFIXTURES_TEST_DB_PASSWORD"),
-		Host:     os.Getenv("GOFIXTURES_TEST_DB_HOST"),
+		Driver:           "postgres",
+		Database:         os.Getenv("GOFIXTURES_TEST_DB_NAME"),
+		User:             os.Getenv("GOFIXTURES_TEST_DB_USER"),
+		Password:         os.Getenv("GOFIXTURES_TEST_DB_PASSWORD"),
+		Host:             os.Getenv("GOFIXTURES_TEST_DB_HOST"),
+		AutoCreateTables: true,
 	}
-	datastore := New()
-	err := datastore.Connect(dbConfig)
+	datastore := New(dbConfig)
+	err := datastore.Connect()
 	if err != nil {
 		t.Error(err)
 		t.Fail()
 	}
-	// prepare database tables
-	prepareDatastoreTables(datastore.(*postgresDatastore))
 	err = datastore.Insert(fixture)
 	if err != nil {
 		t.Error(err)
@@ -67,14 +57,12 @@ func BenchmarkInsertion(b *testing.B) {
 		Password: os.Getenv("GOFIXTURES_TEST_DB_PASSWORD"),
 		Host:     os.Getenv("GOFIXTURES_TEST_DB_HOST"),
 	}
-	datastore := New()
-	err := datastore.Connect(dbConfig)
+	datastore := New(dbConfig)
+	err := datastore.Connect()
 	if err != nil {
 		b.Error(err)
 		b.Fail()
 	}
-	// prepare database tables
-	prepareDatastoreTables(datastore.(*postgresDatastore))
 	for i := 0; i < b.N; i++ {
 		fixture := prepareTestData(b.N)
 		err := datastore.Insert(fixture)

--- a/entity/dbconf.go
+++ b/entity/dbconf.go
@@ -4,12 +4,13 @@ import "io"
 
 // DBConfig resembles the configurations needed to connect to a datastore
 type DBConfig struct {
-	Driver   string `json:"driver" yaml:"driver"`
-	Database string `json:"database" yaml:"database"`
-	User     string `json:"user" yaml:"user"`
-	Password string `json:"password" yaml:"password"`
-	Host     string `json:"host" yaml:"host"`
-	Port     int    `json:"port" yaml:"port"`
+	Driver           string `json:"driver" yaml:"driver"`
+	Database         string `json:"database" yaml:"database"`
+	User             string `json:"user" yaml:"user"`
+	Password         string `json:"password" yaml:"password"`
+	Host             string `json:"host" yaml:"host"`
+	Port             int    `json:"port" yaml:"port"`
+	AutoCreateTables bool   `json:"auto_create_tables" yaml:"auto_create_tables"`
 }
 
 // DBConfigInput resembles data read from the configuration file

--- a/feed/cli/cli.go
+++ b/feed/cli/cli.go
@@ -18,6 +18,7 @@ type feeder struct {
 	dbConfFile string
 	directory  string
 	currentDir string
+	AutoTables bool
 }
 
 func init() {
@@ -40,6 +41,7 @@ func (cli *feeder) readCommandLineFlags() {
 	flag.StringVar(&cli.directory, "dir", defaultFixturesDirectory, "The path of the fixtures directory")
 	flag.StringVar(&cli.filename, "file", "", "The path of a fixture file to load")
 	flag.StringVar(&cli.dbConfFile, "dbconf", defaultDBConfigFile, "The path of dbconf file to load database configuration")
+	flag.BoolVar(&cli.AutoTables, "autoTables", false, "Automatically create tables if they doesn't exists, false by default")
 
 	flag.Parse()
 }

--- a/main.go
+++ b/main.go
@@ -56,12 +56,12 @@ func main() {
 	var datastore dal.Datastore
 	switch dbConf.Driver {
 	case "postgres":
-		datastore = postgres.New()
+		datastore = postgres.New(dbConf)
 	default:
 		feeder.Error(errors.New("unsupported database driver"), true)
 	}
 	feeder.Print("attempting to connect to datastore...")
-	err = datastore.Connect(dbConf)
+	err = datastore.Connect()
 	if err != nil {
 		feeder.Error(err, true)
 	}


### PR DESCRIPTION
Add a db configuration item that allows the database layer to create table if it doesn't exist,
right now its really simple, just creates VARCHAR columns, later on it should be able to detect the field type on its own, or maybe better ask the user to select a type for each field ?